### PR TITLE
Fix crash and abort

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -67,11 +67,11 @@ auto Application::execute(const std::string& cmd) -> void
     if (j["action"] == "add") {
         set_dimensions_from_json(j);
         image = Image::load(terminal, *dimensions, j["path"], *logger);
-        canvas->init(*dimensions, image);
         if (!image) {
             logger->warn("Unable to load image file.");
             return;
         }
+        canvas->init(*dimensions, image);
         canvas->draw();
     } else if (j["action"] == "remove") {
         logger->info("Removing image.");

--- a/src/tmux.cpp
+++ b/src/tmux.cpp
@@ -85,7 +85,7 @@ int tmux::get_statusbar_offset()
 {
     std::string cmd = "tmux display -p '#{status},#{status-position}'";
     auto output = util::str_split(os::exec(cmd), ",");
-    if (output[1] != "top") return 0;
+    if (output[1] != "top" || output[0] == "off") return 0;
     if (output[0] == "on") return 1;
     return std::stoi(output[0]);
 }


### PR DESCRIPTION
Completes 6966c49 that fixed #13 (prevents an exception) and fixes a crash due to dereferencing of `nullptr`.