### PR TITLE
Build and memory bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,6 @@ target_link_libraries(ueberzug PUBLIC
 )
 
 install(TARGETS ueberzug
-    CONFIGURATIONS Release
+    CONFIGURATIONS Release Debug
     RUNTIME DESTINATION bin)
 

--- a/include/application.hpp
+++ b/include/application.hpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <memory>
 #include <atomic>
+#include <thread>
 #include <cstdlib>
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>

--- a/src/image/libvips.hpp
+++ b/src/image/libvips.hpp
@@ -20,6 +20,7 @@
 #include "image.hpp"
 #include "terminal.hpp"
 #include "dimensions.hpp"
+#include "util/ptr.hpp"
 
 #include <string>
 #include <memory>
@@ -47,7 +48,7 @@ private:
     vips::VImage image;
     vips::VImage backup;
 
-    std::unique_ptr<unsigned char> _data;
+    unique_C_ptr<unsigned char> _data;
     std::filesystem::path path;
     const Terminal& terminal;
     const Flags& flags;

--- a/src/util/x11.cpp
+++ b/src/util/x11.cpp
@@ -91,8 +91,12 @@ int X11Util::get_window_pid(xcb_window_t window) const
         xcb_get_property_reply(connection, property_cookie, nullptr),
     };
 
-    return *reinterpret_cast<int*>
-        (xcb_get_property_value(property_reply.get()));
+    void *start = xcb_get_property_value(property_reply.get());
+    int length = xcb_get_property_value_length(property_reply.get());
+    if (length != sizeof(int)) {
+        return -1;
+    }
+    return *reinterpret_cast<int*>(start);
 }
 
 auto X11Util::get_pid_window_map() const -> std::unordered_map<unsigned int, xcb_window_t>


### PR DESCRIPTION
Couldn't build recent versions due to missing `#include <thread>`, `make install` also stopped working due to what seems to be a CMake bug. I'm not sure if forbidding installation in debug makes sense in general, because I used debug build with `-fsanitize=address` to find reasons behind crashes:
 - 1 use of uninitialized memory
 - 1 `delete` of memory allocated via `malloc()`

Commit messages contain more details.