### PR TITLE
prefer one time move commands over window rules in wayland sway/hyprland

### DIFF
--- a/src/canvas/wayland/config/hyprland.cpp
+++ b/src/canvas/wayland/config/hyprland.cpp
@@ -128,7 +128,7 @@ void HyprlandSocket::remove_borders(const std::string_view appid)
 
 void HyprlandSocket::move_window(const std::string_view appid, int xcoord, int ycoord)
 {
-    const auto payload = fmt::format("/keyword windowrulev2 move {} {},title:{}", xcoord, ycoord, appid);
+    const auto payload = fmt::format("/dispatch movewindowpixel exact {} {},title:{}", xcoord, ycoord, appid);
     request(payload);
 }
 

--- a/src/canvas/wayland/config/sway.cpp
+++ b/src/canvas/wayland/config/sway.cpp
@@ -118,7 +118,7 @@ void SwaySocket::enable_floating(const std::string_view appid)
 
 void SwaySocket::move_window(const std::string_view appid, int xcoord, int ycoord)
 {
-    std::ignore = ipc_command(appid, fmt::format("move absolute position {} {}", xcoord, ycoord));
+    std::ignore = ipc_command(fmt::format(R"([app_id="{}"] move absolute position {} {})", appid, xcoord, ycoord));
 }
 
 auto SwaySocket::ipc_message(ipc_message_type type, const std::string_view payload) const -> nlohmann::json

--- a/src/canvas/wayland/wayland.cpp
+++ b/src/canvas/wayland/wayland.cpp
@@ -89,6 +89,8 @@ void WaylandCanvas::xdg_surface_configure(void *data, struct xdg_surface *xdg_su
     std::memcpy(canvas->shm->get_data(), canvas->image->data(), canvas->image->size());
     wl_surface_attach(canvas->surface, canvas->shm->buffer, 0, 0);
     wl_surface_commit(canvas->surface);
+
+    canvas->move_window();
 }
 
 void WaylandCanvas::wl_surface_frame_done(void *data, struct wl_callback *callback, [[maybe_unused]] uint32_t time)
@@ -241,7 +243,6 @@ void WaylandCanvas::draw()
     xdg_toplevel_set_app_id(xdg_toplevel, appid.c_str());
     xdg_toplevel_set_title(xdg_toplevel, appid.c_str());
     wl_surface_commit(surface);
-    move_window();
 
     if (image->is_animated()) {
         callback =  wl_surface_frame(surface);


### PR DESCRIPTION
When using ueberzug with vifm, we sometimes want to show an image on either the left panel or the right panel. Each time the location of the image is changed, a window rule is emitted, which caused inconsistent rules. This caused the location of the image sometimes to be wrong in sway (specifically when trying to preview an image once in the left panel, then the right side panel, then the left side panel again). It also doesn't feel right to use window rules at all, and I would prefer to always use one time commands instead, since window rules are remembered by the window manager, which isn't desirable.