### PR TITLE
fix crash when draw/clear commands are issued quickly in wayland

### DIFF
--- a/src/canvas/wayland/wayland.cpp
+++ b/src/canvas/wayland/wayland.cpp
@@ -78,7 +78,7 @@ void WaylandCanvas::xdg_surface_configure(void *data, struct xdg_surface *xdg_su
     auto *canvas = reinterpret_cast<WaylandCanvas*>(data);
     xdg_surface_ack_configure(xdg_surface, serial);
 
-    std::unique_lock lock {canvas->draw_mutex};
+    std::scoped_lock lock {canvas->draw_mutex};
     if (!canvas->can_draw.load()) {
         return;
     }
@@ -94,7 +94,7 @@ void WaylandCanvas::wl_surface_frame_done(void *data, struct wl_callback *callba
 {
     auto *canvas = reinterpret_cast<WaylandCanvas*>(data);
     wl_callback_destroy(callback);
-    std::unique_lock lock {canvas->draw_mutex};
+    std::scoped_lock lock {canvas->draw_mutex};
     if (!canvas->can_draw.load()) {
         return;
     }
@@ -164,7 +164,7 @@ void WaylandCanvas::hide()
 WaylandCanvas::~WaylandCanvas()
 {
     can_draw.store(false);
-    std::unique_lock lock {draw_mutex};
+    std::scoped_lock lock {draw_mutex};
     stop_flag.store(true);
     if (event_handler.joinable()) {
         event_handler.join();
@@ -256,7 +256,7 @@ void WaylandCanvas::clear()
         return;
     }
     can_draw.store(false);
-    std::unique_lock lock {draw_mutex};
+    std::scoped_lock lock {draw_mutex};
     if (xdg_toplevel != nullptr) {
         xdg_toplevel_destroy(xdg_toplevel);
     }

--- a/src/canvas/wayland/wayland.hpp
+++ b/src/canvas/wayland/wayland.hpp
@@ -19,7 +19,6 @@
 
 #include "canvas.hpp"
 #include "dimensions.hpp"
-#include "terminal.hpp"
 #include "shm.hpp"
 #include "config.hpp"
 #include "wayland-xdg-shell-client-protocol.h"


### PR DESCRIPTION
the crash happened in xdg_surface_configure function at the line:
    std::memcpy(canvas->shm->get_data(), canvas->image->data(), canvas->image->size());

the cause was a race condition between the thread handling commands, and the wayland thread responsible for handling events. specifically: a "clear" command may be issued before the last "draw" command is done, which will cause the state to be reset before xdg_surface_configure function is run

to reproduce the bug, I created this simple python script
```python
#!/bin/python3

import time
import sys

while True:
    print('{"action": "add", "identifier": "preview", "x": "0", "y": "0", "width": 100, "height": 100, "scaler": "contain", "path": "/home/theartful/Pictures/Wallpapers/alphonse.png"}\n', flush=True);

    time.sleep(0.15)

    print('{"action": "remove", "identifier": "preview"}\n', flush=True)
    sys.stdout.flush()
```
and ran
```
./script.py | ueberzug layer
```
and within a couple of seconds, ueberzug crashed.