### PR TITLE
use feature detection to test for std::execution support

### DIFF
--- a/src/canvas/iterm2/iterm2.cpp
+++ b/src/canvas/iterm2/iterm2.cpp
@@ -28,10 +28,10 @@
 
 #include <spdlog/spdlog.h>
 #include <fmt/format.h>
-#ifndef __APPLE__
-#   include <execution>
-#else
+#if !defined(__cpp_lib_execution) || (__cpp_lib_execution < 201902L)
 #   include <oneapi/tbb.h>
+#else
+#   include <execution>
 #endif
 
 namespace fs = std::filesystem;
@@ -97,7 +97,7 @@ auto Iterm2::process_chunks(const std::string_view filename, int chunk_size, siz
         chunks.push_back(std::move(chunk));
     }
 
-#ifdef __APPLE__
+#if !defined(__cpp_lib_execution) || (__cpp_lib_execution < 201902L)
     oneapi::tbb::parallel_for_each(std::begin(chunks), std::end(chunks), Iterm2Chunk());
 #else
     std::for_each(std::execution::par_unseq, std::begin(chunks), std::end(chunks), Iterm2Chunk::process_chunk);

--- a/src/canvas/kitty/kitty.cpp
+++ b/src/canvas/kitty/kitty.cpp
@@ -23,10 +23,10 @@
 #include <fmt/format.h>
 
 #include <iostream>
-#ifndef __APPLE__
-#   include <execution>
-#else
+#if !defined(__cpp_lib_execution) || (__cpp_lib_execution < 201902L)
 #   include <oneapi/tbb.h>
+#else
+#   include <execution>
 #endif
 
 Kitty::Kitty(std::unique_ptr<Image> new_image, std::shared_ptr<std::mutex> stdout_mutex):
@@ -99,7 +99,7 @@ auto Kitty::process_chunks() -> std::vector<KittyChunk>
     }
     chunks.emplace_back(ptr + idx * chunk_size, last_chunk_size);
 
-#ifdef __APPLE__
+#if !defined(__cpp_lib_execution) || (__cpp_lib_execution < 201902L)
     oneapi::tbb::parallel_for_each(std::begin(chunks), std::end(chunks), KittyChunk());
 #else
     std::for_each(std::execution::par_unseq, std::begin(chunks), std::end(chunks), KittyChunk::process_chunk);


### PR DESCRIPTION
builds were failing on linux with clang, since the previous solution
depended on `__APPLE__`

Signed-off-by: Robert Günzler <r@gnzler.io>
