### PR TITLE
docs: add command line to install required libs on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Must be installed in order to build.
 - openssl
 - tbb
 
+### Install dependencies on Ubuntu
+
+```
+apt-get install libssl-dev libvips-dev libsixel-dev libchafa-dev libtbb-dev
+```
+
 ## Downloadable dependencies
 
 Required for building, if they are not installed, they will be downloaded


### PR DESCRIPTION
otherwise user might spend time to search the exactly package name