### PR TITLE
fix: crash in hyprland 0.40.0

### DIFF
--- a/src/canvas/wayland/config/hyprland.cpp
+++ b/src/canvas/wayland/config/hyprland.cpp
@@ -29,8 +29,14 @@ using njson = nlohmann::json;
 
 HyprlandSocket::HyprlandSocket(const std::string_view signature)
     : logger(spdlog::get("wayland")),
-      socket_path(fmt::format("/tmp/hypr/{}/.socket.sock", signature))
+      socket_path()
 {
+    std::string xdg_runtime_dir = std::getenv("XDG_RUNTIME_DIR");
+    if (!xdg_runtime_dir.empty()) {
+        socket_path = fmt::format("{}/hypr/{}/.socket.sock", xdg_runtime_dir, signature);
+    } else {
+        socket_path = fmt::format("/tmp/hypr/{}/.socket.sock", signature);
+    }
     logger->info("Using hyprland socket {}", socket_path);
     const auto active = request_result("j/activewindow");
     address = active.at("address");

--- a/src/canvas/wayland/config/hyprland.cpp
+++ b/src/canvas/wayland/config/hyprland.cpp
@@ -20,7 +20,6 @@
 #include "util/socket.hpp"
 
 #include <algorithm>
-#include <filesystem>
 
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>

--- a/src/canvas/wayland/config/hyprland.cpp
+++ b/src/canvas/wayland/config/hyprland.cpp
@@ -20,6 +20,7 @@
 #include "util/socket.hpp"
 
 #include <algorithm>
+#include <filesystem>
 
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
@@ -32,9 +33,11 @@ HyprlandSocket::HyprlandSocket(const std::string_view signature)
       socket_path()
 {
     std::string xdg_runtime_dir = std::getenv("XDG_RUNTIME_DIR");
-    if (!xdg_runtime_dir.empty()) {
-        socket_path = fmt::format("{}/hypr/{}/.socket.sock", xdg_runtime_dir, signature);
-    } else {
+    std::string hypr_rtdir = fmt::format("{}/hypr", xdg_runtime_dir);
+    if (!xdg_runtime_dir.empty() && std::filesystem::exists(hypr_rtdir)) {
+            socket_path = fmt::format("{}/{}/.socket.sock", hypr_rtdir, signature);
+    }
+    else {
         socket_path = fmt::format("/tmp/hypr/{}/.socket.sock", signature);
     }
     logger->info("Using hyprland socket {}", socket_path);


### PR DESCRIPTION
Hyprland moves `/tmp/hypr` to `$XDG_RUNTIME_DIR/hypr` ([hyprwm/Hyprland@a5a6480](https://github.com/hyprwm/Hyprland/commit/a5a648091760ac002120fab18247e5292b6482de)). This causes ueberzugpp to crash and abort (SIGABRT).

Check if `$XDG_RUNTIME_DIR/hypr` exists. If so, use it. If not, use `/tmp/hypr` for older Hyprland version.