### PR TITLE
Set minimum CMake version to 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <https://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.22...3.28 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21...3.28 FATAL_ERROR)
 
 set(UEBERZUGPP_VERSION 2.9.6)
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Don't know why 3.18 was changed to 3.22, but building with 3.21 produces no errors or warnings, so don't limit the environment unnecessarily.