### PR TITLE
Fix image not hiding when switching between tmux sessions

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -124,6 +124,8 @@ void Application::handle_tmux_hook(const std::string_view hook)
          [this] {
              if (tmux::is_window_focused()) {
                  canvas->show();
+             } else {
+                 canvas->hide();
              }
          }},
         {"session-window-changed",


### PR DESCRIPTION
This pull request fixes [Issue 211](https://github.com/jstkdng/ueberzugpp/issues/211#issue-2448780763), by which ueberzugpp does not hide when switching between tmux sessions.

I'm happy to accommodate changes to my code if needed for approval of the PR, let me know.