### PR TITLE
Fix Images opened in an unfocussed Tmux window are overlaid on top of the active window/session

### DIFF
--- a/include/tmux.hpp
+++ b/include/tmux.hpp
@@ -29,6 +29,7 @@ namespace tmux
 
     auto is_used() -> bool;
     auto is_window_focused() -> bool;
+    auto is_session_attached() -> bool;
 
     auto get_client_pids() -> std::optional<std::vector<int>>;
 

--- a/src/canvas/x11/x11.cpp
+++ b/src/canvas/x11/x11.cpp
@@ -198,6 +198,10 @@ void X11Canvas::add_image(const std::string &identifier, std::unique_ptr<Image> 
         }
         windows.insert({window_id, window});
         image_windows.at(identifier).insert({window_id, window});
+        if (tmux::is_used() && !tmux::is_window_focused()) {
+          window->hide();
+          return;
+        }
         window->show();
     });
 

--- a/src/tmux.cpp
+++ b/src/tmux.cpp
@@ -21,7 +21,6 @@
 #include <array>
 #include <fmt/format.h>
 #include <string>
-#include <utility>
 
 constexpr auto session_hooks = std::to_array<std::string_view>(
     {"session-window-changed", "client-detached", "window-layout-changed"});

--- a/src/tmux.cpp
+++ b/src/tmux.cpp
@@ -58,7 +58,6 @@ auto tmux::get_pane() -> std::string
 
 auto tmux::get_client_pids() -> std::optional<std::vector<int>>
 {
-
     if (!tmux::is_used()) {
         return {};
     }
@@ -72,7 +71,6 @@ auto tmux::get_client_pids() -> std::optional<std::vector<int>>
        cmd = fmt::format("tmux list-clients -F '#{{client_pid}}'");
     }
 
-    // const auto cmd = fmt::format("tmux list-clients -F '#{{client_pid}}'");
     const auto output = os::exec(cmd);
 
     for (const auto &line : util::str_split(output, "\n")) {


### PR DESCRIPTION
Addresses [issue  213](https://github.com/jstkdng/ueberzugpp/issues/213), namely: 

- Fix starting `ueberzugpp` in an unfocussed window or session results in image being generated on top of the focussed window and session, instead of hidden in the correct ones, and also in the wrong position.

Additionally:
 
- Removes unused include of the `utilities` library, introduced in [PR #212](https://github.com/jstkdng/ueberzugpp/pull/212)
