### PR TITLE
Fix X11 and Wayland - Images opened in unfocussed Tmux window overlaid on top of active window/session

### DIFF
--- a/include/application.hpp
+++ b/include/application.hpp
@@ -61,6 +61,7 @@ class Application
     void set_silent();
     void socket_loop();
     void daemonize();
+    void init_visibility();
 };
 
 #endif

--- a/include/tmux.hpp
+++ b/include/tmux.hpp
@@ -29,6 +29,7 @@ namespace tmux
 
     auto is_used() -> bool;
     auto is_window_focused() -> bool;
+    auto is_session_attached() -> bool;
 
     auto get_client_pids() -> std::optional<std::vector<int>>;
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -110,6 +110,7 @@ void Application::execute(const std::string_view cmd)
             return;
         }
         canvas->add_image(identifier, std::move(image));
+        init_visibility();
     } else if (action == "remove") {
         canvas->remove_image(identifier);
     } else {
@@ -238,6 +239,14 @@ void Application::socket_loop()
             execute(cmd);
         }
     }
+}
+
+void Application::init_visibility() {
+        if (tmux::is_used() && !tmux::is_window_focused()) {
+          canvas->hide();
+          return;
+        }
+        canvas->show();
 }
 
 void Application::print_header()

--- a/src/canvas/x11/x11.cpp
+++ b/src/canvas/x11/x11.cpp
@@ -198,11 +198,7 @@ void X11Canvas::add_image(const std::string &identifier, std::unique_ptr<Image> 
         }
         windows.insert({window_id, window});
         image_windows.at(identifier).insert({window_id, window});
-        if (tmux::is_used() && !tmux::is_window_focused()) {
-          window->hide();
-          return;
-        }
-        window->show();
+        window->hide();
     });
 
     draw(identifier);

--- a/src/canvas/x11/x11.cpp
+++ b/src/canvas/x11/x11.cpp
@@ -198,6 +198,10 @@ void X11Canvas::add_image(const std::string &identifier, std::unique_ptr<Image> 
         }
         windows.insert({window_id, window});
         image_windows.at(identifier).insert({window_id, window});
+        if (tmux::is_used() && !tmux::is_window_focused()) {
+          window->hide();
+          return;
+        }
         window->show();
     });
 

--- a/src/tmux.cpp
+++ b/src/tmux.cpp
@@ -21,7 +21,6 @@
 #include <array>
 #include <fmt/format.h>
 #include <string>
-#include <utility>
 
 constexpr auto session_hooks = std::to_array<std::string_view>(
     {"session-window-changed", "client-detached", "window-layout-changed"});

--- a/src/tmux.cpp
+++ b/src/tmux.cpp
@@ -58,7 +58,6 @@ auto tmux::get_pane() -> std::string
 
 auto tmux::get_client_pids() -> std::optional<std::vector<int>>
 {
-
     if (!tmux::is_used()) {
         return {};
     }
@@ -72,7 +71,6 @@ auto tmux::get_client_pids() -> std::optional<std::vector<int>>
        cmd = fmt::format("tmux list-clients -F '#{{client_pid}}'");
     }
 
-    // const auto cmd = fmt::format("tmux list-clients -F '#{{client_pid}}'");
     const auto output = os::exec(cmd);
 
     for (const auto &line : util::str_split(output, "\n")) {


### PR DESCRIPTION
Fixes [issue  213](https://github.com/jstkdng/ueberzugpp/issues/213), on both Wayland and X11. 

**Note that for X11, a small change to `add_image` in `x11.cpp` was still required, to ensure no flickering (even if just for an instant) in the active session when initializing a new image from an unfocussed session or window.** I tested in Wayland, and no change of that module was required in that case.

- Fix starting `ueberzugpp` in an unfocussed window or session results in image being generated on top of the focussed window and session, instead of hidden in the correct ones, and also in the wrong position.

Additionally:
 
- Removes unused include of the `utilities` library, introduced in [PR #212](https://github.com/jstkdng/ueberzugpp/pull/212)
