### PR TITLE
Hyprland: Make sure image window is moved to correct workspace

### DIFF
--- a/src/canvas/wayland/config/hyprland.cpp
+++ b/src/canvas/wayland/config/hyprland.cpp
@@ -137,8 +137,19 @@ void HyprlandSocket::remove_borders(const std::string_view appid)
     request(payload);
 }
 
+void HyprlandSocket::change_workspace(const std::string_view appid, int workspaceid)
+{
+    const auto payload = fmt::format("/dispatch movetoworkspacesilent {},title:{}", workspaceid, appid);
+    request(payload);
+}
+
 void HyprlandSocket::move_window(const std::string_view appid, int xcoord, int ycoord)
 {
+    auto terminal = get_active_window();
+    const auto &workspace = terminal.at("workspace");
+    const int workspaceid = workspace.at("id");
+    change_workspace(appid, workspaceid);
+    
     int res_x = xcoord;
     int res_y = ycoord;
     if (output_scale > 1.0F) {

--- a/src/canvas/wayland/config/hyprland.hpp
+++ b/src/canvas/wayland/config/hyprland.hpp
@@ -38,6 +38,7 @@ class HyprlandSocket : public WaylandConfig
     void enable_floating(std::string_view appid);
     void remove_borders(std::string_view appid);
     void remove_rounding(std::string_view appid);
+    void change_workspace(std::string_view appid, int workspaceid);
     void request(std::string_view payload);
     auto request_result(std::string_view payload) -> nlohmann::json;
     auto get_active_window() -> nlohmann::json;


### PR DESCRIPTION
The image window was always opened in the currently focused workspace instead of the workspace belonging to the terminal window. I wasnt sure implementation wise if the change_workspace should be called in wayland.cpp (like move_window) since it can be kept hidden from it without problems.