### PR TITLE
add ability to overridde default temporary directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,22 @@ The configuration file should have this format.
 The most helpful is the `output` variable as that can be used to force
 ueberzugpp to output images with a particular method.
 
-3. By default, commands are sent to ueberzug++ through stdin, this is enough in
+3. You can configure ueberzug++ directory for temporary files (logs, sockets)
+   with `${UEBERZUGPP_TMPDIR}` environment variable (by default it is system temporary directory)
+
+```sh
+export UEBERZUGPP_TMPDIR="${TMPDIR}/ueberzugpp"
+```
+
+4. By default, commands are sent to ueberzug++ through stdin, this is enough in
    some cases. In some terminals and application combinations (e.g. ranger + wezterm + zellij)
    using stdin to send commands doesn't work properly or ueberzug++ could fail to
    start altogether. In those cases, the user may send commands to ueberzug++ through
-   a unix socket. By default, ueberzug++ will listen to commands on /tmp/ueberzug_{$USER}.sock.
+   a unix socket. By default, ueberzug++ will listen to commands on `${UEBERZUGPP_TMPDIR}/ueberzugpp-${PID}.socket`.
 
 New software is encouraged to use sockets instead of stdin as they cover more cases.
 
-4. You can then feed Ueberzug with json objects to display an image or make it disappear.
+5. You can then feed Ueberzug with json objects to display an image or make it disappear.
 
 - json object to display the image:
 

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -51,6 +51,7 @@ void send_command(const Flags &flags);
 void clear_terminal_area(int xcoord, int ycoord, int width, int height);
 auto generate_random_string(std::size_t length) -> std::string;
 auto round_up(int num_to_round, int multiple) -> int;
+auto temp_directory_path() -> std::filesystem::path;
 
 auto read_exif_rotation(const std::filesystem::path &path) -> std::optional<std::uint16_t>;
 template <typename T>

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -155,7 +155,7 @@ void Application::handle_tmux_hook(const std::string_view hook)
 void Application::setup_logger()
 {
     const auto log_tmp = util::get_log_filename();
-    const auto log_path = fs::temp_directory_path() / log_tmp;
+    const auto log_path = util::temp_directory_path() / log_tmp;
     try {
         spdlog::flush_on(spdlog::level::debug);
         const auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path);
@@ -243,7 +243,7 @@ void Application::socket_loop()
 void Application::print_header()
 {
     const auto log_tmp = util::get_log_filename();
-    const auto log_path = fs::temp_directory_path() / log_tmp;
+    const auto log_path = util::temp_directory_path() / log_tmp;
     const auto art = fmt::format(R"(
  _   _      _
 | | | |    | |                                _     _

--- a/src/flags.cpp
+++ b/src/flags.cpp
@@ -16,6 +16,7 @@
 
 #include "flags.hpp"
 #include "os.hpp"
+#include "util.hpp"
 
 #include <fmt/format.h>
 #include <fstream>
@@ -27,7 +28,7 @@ using json = nlohmann::json;
 // read configuration file
 Flags::Flags()
 {
-    const auto home = os::getenv("HOME").value_or(fs::temp_directory_path());
+    const auto home = os::getenv("HOME").value_or(util::temp_directory_path());
     const auto config_home = os::getenv("XDG_CONFIG_HOME").value_or(fmt::format("{}/.config", home));
     config_file = fmt::format("{}/ueberzugpp/config.json", config_home);
     if (fs::exists(config_file)) {

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -82,7 +82,7 @@ auto util::get_process_tree_v2(int pid) -> std::vector<Process>
 
 auto util::get_cache_path() -> std::string
 {
-    const auto home = os::getenv("HOME").value_or(fs::temp_directory_path());
+    const auto home = os::getenv("HOME").value_or(util::temp_directory_path());
     const auto cache_home = os::getenv("XDG_CACHE_HOME").value_or(fmt::format("{}/.cache", home));
     return fmt::format("{}/ueberzugpp/", cache_home);
 }
@@ -95,7 +95,7 @@ auto util::get_log_filename() -> std::string
 
 auto util::get_socket_path(int pid) -> std::string
 {
-    return fmt::format("{}/ueberzugpp-{}.socket", fs::temp_directory_path().string(), pid);
+    return fmt::format("{}/ueberzugpp-{}.socket", util::temp_directory_path().string(), pid);
 }
 
 void util::send_socket_message(const std::string_view msg, const std::string_view endpoint)
@@ -254,4 +254,9 @@ auto util::round_up(int num_to_round, int multiple) -> int
     }
 
     return num_to_round + multiple - remainder;
+}
+
+auto util::temp_directory_path() -> fs::path
+{
+    return os::getenv("UEBERZUGPP_TMPDIR").value_or(fs::temp_directory_path());
 }


### PR DESCRIPTION
I would like to override `ueberzugpp` default path to `${TMPDIR}` with something like:
```sh
export UEBERZUGPP_TMPDIR="${TMPDIR}/ueberzugpp"
```
so that the log and sockets will be stored there

(for example tmux has similar variable: [TMUX_TMPDIR](https://github.com/tmux/tmux/blob/1.9/CHANGES#L30))
