### PR TITLE
Add missing mutex header

### DIFF
--- a/src/canvas/chafa.hpp
+++ b/src/canvas/chafa.hpp
@@ -21,6 +21,7 @@
 #include "window.hpp"
 
 #include <memory>
+#include <mutex>
 
 #include <chafa.h>
 


### PR DESCRIPTION
Needed with upcoming gcc-16 which no longer transitively provides it.

https://bugs.gentoo.org/957614