### PR TITLE
Guard vips image initialization with try/catch to prevent crashes

### DIFF
--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -234,8 +234,8 @@ auto util::generate_random_string(size_t length) -> std::string
 
 auto util::read_exif_rotation(const fs::path &path) -> std::optional<std::uint16_t>
 {
-    auto image = vips::VImage::new_from_file(path.c_str());
     try {
+        auto image = vips::VImage::new_from_file(path.c_str());
         return image.get_int("orientation");
     } catch (const vips::VError &) {
         return {};


### PR DESCRIPTION
ueberzugpp crashes locally whenever I open a corrupted image, or an image that doesn't exist. I traced the issue to `vips::VImage::new_from_file(path.c_str())` throwing an exception that is not handled.

To reproduce, try passing ueberzug an image that doesn't exist, while using libvips as the image loader.