### PR TITLE
Adding libxcb-res0-dev to Ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Must be installed in order to build.
 ### Install dependencies on Ubuntu
 
 ```
-apt-get install libssl-dev libvips-dev libsixel-dev libchafa-dev libtbb-dev
+apt-get install libssl-dev libvips-dev libsixel-dev libchafa-dev libtbb-dev libxcb-res0-dev
 ```
 
 ## Downloadable dependencies


### PR DESCRIPTION
I am running Ubuntu 25.04. When building from source using the defaults I run into the following:

**COMMAND:**

cmake -DCMAKE_BUILD_TYPE=Release ..

**ERROR:**

CMake Error at /usr/share/cmake-3.31/Modules/FindPkgConfig.cmake:645 (message):
  The following required packages were not found:

   - xcb-res

Call Stack (most recent call first):
  /usr/share/cmake-3.31/Modules/FindPkgConfig.cmake:873 (_pkg_check_modules_internal)
  CMakeLists.txt:119 (pkg_check_modules)


**SOLUTION:**

sudo apt-get install libxcb-res0-dev