### PR TITLE
[BUGFIX] Fix compilation for CLI11 2.6.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,9 +19,14 @@
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
-#include <CLI/ExtraValidators.hpp>
 #include <spdlog/cfg/env.h>
 #include <spdlog/spdlog.h>
+
+#include <CLI/Version.hpp>
+#if (CLI11_VERSION_MAJOR >= 3) || (CLI11_VERSION_MAJOR == 2 && CLI11_VERSION_MINOR >= 6)
+// CLI11 2.6.0 and beyond requires this header file for the CLI::IsMember validator.
+#include <CLI/ExtraValidators.hpp>
+#endif
 
 #include "application.hpp"
 #include "flags.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
+#include <CLI/ExtraValidators.hpp>
 #include <spdlog/cfg/env.h>
 #include <spdlog/spdlog.h>
 


### PR DESCRIPTION
The latest version of CLI11 (v2.6.0) fails to compile due to this change marked in the [changelog](https://github.com/CLIUtils/CLI11/releases/tag/v2.6.0).

> **Changed**
> 
> - Moved several of the validators to `ExtraValidators.hpp` and
>     `ExtraValidators_inl.hpp` files, The compilation of these nonessential
>     validators can be disabled by setting `CLI11_DISABLE_EXTRA_VALIDATORS` to
>     `OFF`. Future additional validators will be behind a compile flag
>     `CLI11_ENABLE_EXTRA_VALIDATORS`. All non-essential validators will be under
>     this option with version 3.0. [#1192](https://github.com/CLIUtils/CLI11/pull/1192)

This pull request simply fixes the issue without interfering with compilation with prior CLI11 versions.